### PR TITLE
Fix: Card Shuffling Suggestion

### DIFF
--- a/src/app/content/[slug]/page.tsx
+++ b/src/app/content/[slug]/page.tsx
@@ -97,7 +97,7 @@ export default function ContentDetailsPage() {
                       ContentCopy,
                     }}
                   />
-                  <ContentFooter />
+                  <ContentFooter currentContentIndex={data.index} />
                 </>
               ) : null}
             </div>

--- a/src/components/ContentFooter/index.tsx
+++ b/src/components/ContentFooter/index.tsx
@@ -10,6 +10,11 @@ import Data from "../../app/content/content.json";
 
 interface DataItem {
   labels: string[];
+  index: number;
+}
+
+interface ContentFooterProps {
+  currentContentIndex: number;
 }
 
 const CardBox = styled(Box)(() => ({
@@ -29,7 +34,9 @@ const shuffleArray = (array: any[]) => {
   }
   return array;
 };
-const ContentFooter = () => {
+const ContentFooter: React.FC<ContentFooterProps> = ({
+  currentContentIndex,
+}) => {
   const [combinedData, setCombinedData] = useState<DataItem[]>([]);
   const [filteredData, setFilteredData] = useState<DataItem[]>([]);
 
@@ -38,10 +45,13 @@ const ContentFooter = () => {
       .then((res) => res.json())
       .then((markdownData) => {
         const combined = [...Data, ...markdownData];
-        setCombinedData(combined);
-        setFilteredData(shuffleArray(combined));
+        const filtered = combined.filter(
+          (item) => item.index !== currentContentIndex,
+        );
+        setCombinedData(filtered);
+        setFilteredData(shuffleArray(filtered));
       });
-  }, []);
+  }, [currentContentIndex]);
 
   return (
     <div className="max-h-96">


### PR DESCRIPTION
Existing card content preview includes current content as suggestion.

Fix updates the card shuffling suggestion to exclude current viewing content in suggestion list.