### PR TITLE
fix: C should only inherent from B

### DIFF
--- a/src/challenges/solidity/constructor.mdx
+++ b/src/challenges/solidity/constructor.mdx
@@ -64,7 +64,7 @@ contract B is A {
 // 1. A
 // 2. B
 // 3. C
-contract C is A, B {
-    constructor(string memory _name, uint256 _data) A(_name) B(_name, _data) {}
+contract C is B {
+    constructor(string memory _name, uint256 _data) B(_name, _data) {}
 }
 ```


### PR DESCRIPTION
If B inherits from A, then C cannot inherit from both A and B; C should only inherit from B.

<img width="1323" alt="image" src="https://github.com/user-attachments/assets/66226a2f-860e-4dc9-b517-22163d327079">
