### PR TITLE
docs: Fix Missing Quotation Mark Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ We encourage contributions that explore these topics in-depth, in the form of ar
 1. Fork this repo
 2. Create a pull request (PR)
    - If adding new content, name your branch as `content-"name"` . Title of PR should ideally be `Add Content: Name of Content`
-   - If updating or fixing previous content, name your branch with the `patch-content-"name"` prefix. Title of PR should ideally be `Patch Content: "Patch Name`"
+   - If updating or fixing previous content, name your branch with the `patch-content-"name"` prefix. Title of PR should ideally be `Patch Content: "Patch Name"`
    - For example, if you are planning to create a content about building with circom, you can follow the following naming guide:
      - Branch name: `content-how-to-build-with-circom`
      - PR Title: `Add Content: How to Build with Circom`


### PR DESCRIPTION
### Description:  
While reviewing the Contribution Guide, I noticed a small but important typo in the section describing naming conventions for PR titles when updating content. The text reads:  

> *PR Title should ideally be `Patch Content: "Patch Name`"*  

The closing quotation mark after **Patch Name** is missing, which might cause confusion for contributors.  

This update corrects the sentence to:  
**PR Title should ideally be `Patch Content: "Patch Name"`**  

This ensures proper syntax and clarity in the instructions.