### PR TITLE
Sort content by `published` field

### DIFF
--- a/src/app/content/List/index.tsx
+++ b/src/app/content/List/index.tsx
@@ -12,7 +12,7 @@ import NoData from "@/components/NoData";
 
 interface DataItem {
   labels: string[];
-  index: number;
+  published: string;
 }
 
 const List = (props) => {
@@ -51,7 +51,7 @@ const List = (props) => {
           }}
         >
           {filteredData
-            .sort((a, b) => b.index - a.index)
+            .sort((a, b) => new Date(b.published).getTime() - new Date(a.published).getTime())
             .map((item) => (
               <Card
                 color="purple"

--- a/src/contents/0x-on-scroll.mdx
+++ b/src/contents/0x-on-scroll.mdx
@@ -1,6 +1,5 @@
 ---
 name: "How to fetch live swap prices with 0x Swap API on Scroll"
-index: 7
 summary: Learn how to embed crypto trading into your app using 0x Swap API
 author: Jessica Lin
 authorIcon: https://avatars.githubusercontent.com/u/8042156?v=4

--- a/src/contents/build-chance-based-dapp.mdx
+++ b/src/contents/build-chance-based-dapp.mdx
@@ -1,6 +1,5 @@
 ---
 name: "How to build contracts with tamper-proof unpredictability"
-index: 9
 summary: Learn how to build chance-based contracts using verifiable randomness provided by Anyrand (powered by drand)
 author: Anyrand
 authorIcon: https://pbs.twimg.com/profile_images/1839241810473865216/dP3Tfkou_400x400.jpg

--- a/src/contents/exploring-solidity-objects-address-part-1.mdx
+++ b/src/contents/exploring-solidity-objects-address-part-1.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Exploring Solidity Objects: Address - Part 1"
-index: 1
 summary: Dive into the world of Solidity in pursuit of leveling up! Starting with Address object.
 author: RH
 authorIcon: https://pbs.twimg.com/profile_images/1751242830398287872/8VKShh46.jpg

--- a/src/contents/exploring-solidity-objects-address-part-2.mdx
+++ b/src/contents/exploring-solidity-objects-address-part-2.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Exploring Solidity Objects: Address - Part 2"
-index: 2
 summary: Dive into the world of Solidity in pursuit of leveling up! Venturing into delegatecall and staticcall functions!
 author: RH
 authorIcon: https://pbs.twimg.com/profile_images/1751242830398287872/8VKShh46.jpg

--- a/src/contents/guardrail-ai-agents.mdx
+++ b/src/contents/guardrail-ai-agents.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Guardrail AI Agents with ZKML"
-index: 11
 summary: Create an AI Agent with Guardrails using EZKL.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/how-to-fetch-scroll-canvas-badges.mdx
+++ b/src/contents/how-to-fetch-scroll-canvas-badges.mdx
@@ -1,6 +1,5 @@
 ---
 name: "How to Fetch Scroll Canvas Badges"
-index: 12
 summary: Load Badges by querying EAS and the Scroll Canvas Profile Registry.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/huracan.mdx
+++ b/src/contents/huracan.mdx
@@ -1,6 +1,5 @@
 ---
 name: "🌀Huracan"
-index: 6
 summary: Learn ZK by Deploying a Battle Tested Project.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/l1sload-guide-read-arrays-mappings-structs.mdx
+++ b/src/contents/l1sload-guide-read-arrays-mappings-structs.mdx
@@ -1,6 +1,5 @@
 ---
 name: "L1SLOAD guide: Reading Data Structures"
-index: 10
 summary: Reading Arrays, Structs and Nested Mappings from L1.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/l1sload-guide-read-the-l1-state-from-l2.mdx
+++ b/src/contents/l1sload-guide-read-the-l1-state-from-l2.mdx
@@ -1,6 +1,5 @@
 ---
 name: "L1SLOAD guide: Read the L1 state from L2"
-index: 8
 summary: This precompile unlocks the Keystore and more, learn how to use it with examples.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/level-up-foundry.mdx
+++ b/src/contents/level-up-foundry.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Level Up: Building with Foundry"
-index: 3
 summary: Learn smart contract development with Foundry, a blazingly fast framework for building and deploying smart contracts!
 author: RH
 authorIcon: https://pbs.twimg.com/profile_images/1751242830398287872/8VKShh46.jpg

--- a/src/contents/privacy-interfaces-on-soldity-zk-wasm.mdx
+++ b/src/contents/privacy-interfaces-on-soldity-zk-wasm.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Privacy Interfaces on Solidity & zk-WASM"
-index: 5
 summary: Keep users' data safe by generating proofs in the browser, on Javascript.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/private-smart-contracts-with-solidity-and-circom.mdx
+++ b/src/contents/private-smart-contracts-with-solidity-and-circom.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Private Smart Contracts with Solidity & Circom"
-index: 4
 summary: Get started with developing privacy applications by combining Circuits and Smart Contracts.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/stablecoins-module0.mdx
+++ b/src/contents/stablecoins-module0.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Stablecoins Module 0: ERC20 Standard Recap"
-index: 13
 summary: Get familiar with the ERC20 format.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/stablecoins-module1.mdx
+++ b/src/contents/stablecoins-module1.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Stablecoins Module 1: Fiat-Backed Stablecoins"
-index: 14
 summary: Create a stablecoin with centralized features.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4

--- a/src/contents/stablecoins-module2.mdx
+++ b/src/contents/stablecoins-module2.mdx
@@ -1,6 +1,5 @@
 ---
 name: "Stablecoins Module 2: Crypto-Collateralized Stablecoins"
-index: 15
 summary: Create a stablecoin with on-chain overcollateralized debt.
 author: FilosofiaCodigo
 authorIcon: https://avatars.githubusercontent.com/u/707484?s=96&v=4


### PR DESCRIPTION
The content is currently sorted by the sequential `index` field. In this PR we sort using the already existing `published` date field and remove all references to `index` since now it would be unnecessary.

**Rationale**

Sorting by a published field will make the process of adding new articles easier since we don't have to coordinate which article goes first. Now multiple articles from different contributors can be submitted simultaneously without coordination between them. This makes this repo more friendly for external open source contributions.